### PR TITLE
Fix responsiveness issues for widget

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,15 @@ function App(props) {
   const { color, font, headerTitle, gtagId, ...widgetProps } = props;
   const locale = widgetProps.locale;
   const [loading, setLoading] = useState(true);
+  const heightValue = widgetProps.height;
+  const isNumericHeight =
+    typeof heightValue === 'number' || (typeof heightValue === 'string' && /^\d+$/.test(heightValue));
+  const resolvedHeight =
+    heightValue != null && heightValue !== ''
+      ? isNumericHeight
+        ? `${heightValue}px`
+        : heightValue
+      : '1000px';
 
   useEffect(() => {
     try {
@@ -52,7 +61,7 @@ function App(props) {
 
   return (
     <WidgetContextProvider widgetProps={{ ...widgetProps, font }}>
-      <div className="widget-layout" style={{ height: widgetProps.height + 'px' }}>
+      <div className="widget-layout" style={{ height: resolvedHeight }}>
         <Suspense fallback={<Loader />}>
           {headerTitle && (
             <Heading

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,19 +13,35 @@ import { initGoogleAnalytics } from './utils/googleAnalytics';
 import 'dayjs/locale/en';
 import 'dayjs/locale/fr';
 
+const DEFAULT_WIDGET_HEIGHT = '1000px';
+
+function resolveWidgetHeight(height) {
+  if (typeof height === 'number') {
+    return Number.isFinite(height) ? `${height}px` : DEFAULT_WIDGET_HEIGHT;
+  }
+
+  if (typeof height === 'string') {
+    const normalizedHeight = height.trim();
+
+    if (!normalizedHeight) {
+      return DEFAULT_WIDGET_HEIGHT;
+    }
+
+    if (/^(?:\d+|\d*\.\d+)$/.test(normalizedHeight)) {
+      return `${normalizedHeight}px`;
+    }
+
+    return normalizedHeight;
+  }
+
+  return DEFAULT_WIDGET_HEIGHT;
+}
+
 function App(props) {
   const { color, font, headerTitle, gtagId, ...widgetProps } = props;
   const locale = widgetProps.locale;
   const [loading, setLoading] = useState(true);
-  const heightValue = widgetProps.height;
-  const isNumericHeight =
-    typeof heightValue === 'number' || (typeof heightValue === 'string' && /^\d+$/.test(heightValue));
-  const resolvedHeight =
-    heightValue != null && heightValue !== ''
-      ? isNumericHeight
-        ? `${heightValue}px`
-        : heightValue
-      : '1000px';
+  const resolvedHeight = resolveWidgetHeight(widgetProps.height);
 
   useEffect(() => {
     try {

--- a/src/components/card/EventCard/eventCard.css
+++ b/src/components/card/EventCard/eventCard.css
@@ -3,7 +3,6 @@
   width: 100%;
   max-width: 100%;
   min-width: 0;
-  border-radius: 10px;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/src/components/card/EventCard/eventCard.css
+++ b/src/components/card/EventCard/eventCard.css
@@ -1,7 +1,8 @@
 #calendar-widget > .widget-layout .event-card {
-  flex: 1 1 auto;
-  max-width: 371px;
-  min-width: 246px;
+  flex: 1 1 100%;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 10px;
   overflow: hidden;
   display: flex;
@@ -26,21 +27,21 @@
 
 @media (max-width: 550px) {
   #calendar-widget > .widget-layout .event-card {
-    width: 371px;
+    width: 100%;
   }
 }
 @media (min-width: 550px) and (max-width: 768px) {
   #calendar-widget > .widget-layout .event-card {
-    width: 246px;
+    width: 100%;
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   #calendar-widget > .widget-layout .event-card {
-    width: 246px;
+    width: 100%;
   }
 }
 @media (min-width: 1025px) {
   #calendar-widget > .widget-layout .event-card {
-    width: 246px;
+    max-width: 371px;
   }
 }

--- a/src/components/filterPanel/FilterPanel.jsx
+++ b/src/components/filterPanel/FilterPanel.jsx
@@ -134,8 +134,8 @@ const FilterPanel = ({ isFilterOpen, filters, setIsFilterOpen, iconRef, t }) => 
           boxShadow: 'md',
           padding: '12px',
           borderRadius: 'md',
-          minWidth: '350px',
-          maxWidth: '350px',
+          width: 'min(350px, calc(100vw - 24px))',
+          maxWidth: 'calc(100vw - 24px)',
         }}
       >
         {selectedFilters &&

--- a/src/components/panel/panel.css
+++ b/src/components/panel/panel.css
@@ -6,7 +6,7 @@
   min-height: 100px;
   flex: 1;
   height: 100%;
-  padding: 0 24px;
+  padding: 0 clamp(12px, 4vw, 24px);
 }
 
 #calendar-widget > .widget-layout .result-panel-wrapper {
@@ -28,7 +28,8 @@
 }
 
 #calendar-widget > .widget-layout .loader-wrapper .skeleton-card-wrapper {
-  width: 232px;
+  width: 100%;
+  max-width: 371px;
   height: 400px;
   margin: 0px 8px 32px 8px;
   padding: 16px;
@@ -39,28 +40,22 @@
 
 #calendar-widget > .widget-layout .loader-wrapper > div {
   display: grid;
+  width: 100%;
+  max-width: 980px;
   justify-content: center;
   gap: 8px;
-  grid-template-columns: 1fr;
-  justify-items: center;
-}
-
-@media (min-width: 820px) and (max-width: 1060px) {
-  #calendar-widget > .widget-layout .loader-wrapper > div {
-    padding: 0px;
-    grid-template-columns: repeat(3, 246px);
-  }
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 246px), 1fr));
+  justify-items: stretch;
 }
 
 @media (max-width: 550px) {
   #calendar-widget > .widget-layout .loader-wrapper .skeleton-card-wrapper {
-    width: 371px;
+    width: 100%;
     margin: 0px 0px 16px 0px;
   }
 
   #calendar-widget > .widget-layout .loader-wrapper > div {
-    padding: 0px;
-    grid-template-columns: repeat(1, 246px);
+    padding: 0;
   }
 }
 
@@ -70,13 +65,12 @@
   }
 
   #calendar-widget > .widget-layout .loader-wrapper > div {
-    padding: 0px;
-    grid-template-columns: repeat(2, 246px);
+    padding: 0;
   }
 }
 
 @media (min-width: 1060px) {
   #calendar-widget > .widget-layout .loader-wrapper > div {
-    grid-template-columns: repeat(4, 246px);
+    grid-template-columns: repeat(auto-fit, minmax(246px, 1fr));
   }
 }

--- a/src/components/resultHeader/resultHeader.css
+++ b/src/components/resultHeader/resultHeader.css
@@ -2,32 +2,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0px 24px 16px 24px;
+  padding: 0 clamp(12px, 4vw, 24px) 16px;
   width: 100%;
-}
-
-@media (max-width: 550px) {
-  #calendar-widget > .widget-layout .result-header {
-    max-width: 417px;
-  }
-}
-
-@media (min-width: 550px) and (max-width: 820px) {
-  #calendar-widget > .widget-layout .result-header {
-    max-width: 540px;
-  }
-}
-
-@media (min-width: 820px) and (max-width: 1060px) {
-  #calendar-widget > .widget-layout .result-header {
-    max-width: 717px;
-  }
-}
-
-@media (min-width: 1060px) {
-  #calendar-widget > .widget-layout .result-header {
-    max-width: 981px;
-  }
+  max-width: 980px;
+  margin: 0 auto;
 }
 
 #calendar-widget > .widget-layout .result-header-text {

--- a/src/components/results/results.css
+++ b/src/components/results/results.css
@@ -8,26 +8,11 @@
 
 #calendar-widget > .widget-layout .grid-container {
   display: grid;
+  width: 100%;
+  max-width: 980px;
+  margin: 0 auto;
   justify-content: center;
   gap: 8px;
-  grid-template-columns: 1fr;
-  justify-items: center;
-}
-
-@media (min-width: 550px) and (max-width: 820px) {
-  #calendar-widget > .widget-layout .grid-container {
-    grid-template-columns: repeat(2, 246px);
-  }
-}
-
-@media (min-width: 820px) and (max-width: 1060px) {
-  #calendar-widget > .widget-layout .grid-container {
-    grid-template-columns: repeat(3, 246px);
-  }
-}
-
-@media (min-width: 1060px) {
-  #calendar-widget > .widget-layout .grid-container {
-    grid-template-columns: repeat(4, 246px);
-  }
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 246px), 1fr));
+  justify-items: stretch;
 }


### PR DESCRIPTION
This pull request improves the responsiveness and layout consistency of the calendar widget across different screen sizes. The changes focus on making card and panel components adapt fluidly to various viewports, simplifying grid and width logic, and enhancing the handling of the widget's height.

**Responsive Layout and Grid Improvements:**

* Updated `.event-card`, `.loader-wrapper`, and `.grid-container` CSS to use `width: 100%` and `max-width` constraints, and replaced fixed-width grid templates with `repeat(auto-fit, minmax(...))` for better responsiveness and cleaner code. [[1]](diffhunk://#diff-10b44918c6557f3732d74e20a8aef62dda5fb7a218d2b9c1ab5783f98efca71bL2-R5) [[2]](diffhunk://#diff-10b44918c6557f3732d74e20a8aef62dda5fb7a218d2b9c1ab5783f98efca71bL29-R45) [[3]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0L31-R32) [[4]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0R43-R58) [[5]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0L73-R74) [[6]](diffhunk://#diff-261a3d038c3d7259ba2fc3e009214b3ab70ec248d58a457197af95e3605bd9c9R11-R17)
* Simplified and unified padding and max-width handling in `.result-header` and `.panel` components, ensuring consistent alignment and spacing at all screen sizes. [[1]](diffhunk://#diff-c60042b09ad29a39d1e89770d392a3f96161526642dc6ffbb11da6906198757aL5-R8) [[2]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0L9-R9)

**Widget Height Handling:**

* Improved the logic for the widget's height in `App.jsx` by normalizing numeric and string values and providing a default fallback, ensuring the widget always displays with an appropriate height. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R20-R28) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661L55-R64)

**Filter Panel Responsiveness:**

* Adjusted the filter panel's width to use `min(350px, calc(100vw - 24px))`, making it fit smaller screens without overflowing.

Overall, these updates make the calendar widget more robust and visually consistent across devices, while simplifying the underlying code for maintainability.