### PR TITLE
Fix card width for single card display

### DIFF
--- a/src/components/card/EventCard/eventCard.css
+++ b/src/components/card/EventCard/eventCard.css
@@ -32,15 +32,17 @@
 @media (min-width: 550px) and (max-width: 768px) {
   #calendar-widget > .widget-layout .event-card {
     width: 100%;
+    max-width: 246px;
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   #calendar-widget > .widget-layout .event-card {
     width: 100%;
+    max-width: 246px;
   }
 }
 @media (min-width: 1025px) {
   #calendar-widget > .widget-layout .event-card {
-    max-width: 371px;
+    max-width: 246px;
   }
 }

--- a/src/components/panel/panel.css
+++ b/src/components/panel/panel.css
@@ -41,11 +41,18 @@
 #calendar-widget > .widget-layout .loader-wrapper > div {
   display: grid;
   width: 100%;
-  max-width: 980px;
+  max-width: 1008px;
   justify-content: center;
   gap: 8px;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 246px), 1fr));
+  grid-template-columns: minmax(0, 1fr);
   justify-items: stretch;
+}
+
+@media (min-width: 550px) and (max-width: 820px) {
+  #calendar-widget > .widget-layout .loader-wrapper > div {
+    grid-template-columns: repeat(2, 246px);
+    justify-items: initial;
+  }
 }
 
 @media (max-width: 550px) {
@@ -69,8 +76,16 @@
   }
 }
 
+@media (min-width: 820px) and (max-width: 1060px) {
+  #calendar-widget > .widget-layout .loader-wrapper > div {
+    grid-template-columns: repeat(3, 246px);
+    justify-items: initial;
+  }
+}
+
 @media (min-width: 1060px) {
   #calendar-widget > .widget-layout .loader-wrapper > div {
-    grid-template-columns: repeat(auto-fit, minmax(246px, 1fr));
+    grid-template-columns: repeat(4, 246px);
+    justify-items: initial;
   }
 }

--- a/src/components/results/Results.jsx
+++ b/src/components/results/Results.jsx
@@ -14,7 +14,7 @@ const Results = () => {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-      <div className="grid-container">
+      <div className={`grid-container ${data?.length === 1 ? 'single-event-grid' : ''}`}>
         {data?.map((item, index) => (
           <EventCard
             key={index}

--- a/src/components/results/results.css
+++ b/src/components/results/results.css
@@ -9,10 +9,42 @@
 #calendar-widget > .widget-layout .grid-container {
   display: grid;
   width: 100%;
-  max-width: 980px;
+  max-width: 1008px;
   margin: 0 auto;
   justify-content: center;
   gap: 8px;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 246px), 1fr));
+  grid-template-columns: minmax(0, 1fr);
   justify-items: stretch;
+}
+
+@media (min-width: 550px) and (max-width: 820px) {
+  #calendar-widget > .widget-layout .grid-container {
+    grid-template-columns: repeat(2, 246px);
+    justify-items: initial;
+  }
+}
+
+@media (min-width: 820px) and (max-width: 1060px) {
+  #calendar-widget > .widget-layout .grid-container {
+    grid-template-columns: repeat(3, 246px);
+    justify-items: initial;
+  }
+}
+
+@media (min-width: 1060px) {
+  #calendar-widget > .widget-layout .grid-container {
+    grid-template-columns: repeat(4, 246px);
+    justify-items: initial;
+  }
+}
+
+#calendar-widget > .widget-layout .grid-container.single-event-grid {
+  grid-template-columns: minmax(min(100%, 246px), 246px);
+  justify-content: center;
+}
+
+@media (max-width: 550px) {
+  #calendar-widget > .widget-layout .grid-container.single-event-grid {
+    grid-template-columns: minmax(min(100%, 371px), 371px);
+  }
 }


### PR DESCRIPTION
This pull request updates the event grid and card layouts to provide more consistent sizing and improved responsiveness across different screen sizes. The main changes involve standardizing the width of event cards, refining grid column behavior for various breakpoints, and adding special handling for displaying a single event.

**Responsive grid and card layout improvements:**

* Standardized the maximum width of `.event-card` to `246px` for all breakpoints, replacing the previous `371px` max-width for large screens. (`src/components/card/EventCard/eventCard.css`)
* Updated grid layouts in both `panel.css` and `results.css` to use fixed-width columns (`246px`) at specific breakpoints (2 columns for small tablets, 3 for medium screens, 4 for large screens), replacing the previous `auto-fit`/`minmax` logic. (`src/components/panel/panel.css`, `src/components/results/results.css`) [[1]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0L44-R57) [[2]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0R79-R89) [[3]](diffhunk://#diff-261a3d038c3d7259ba2fc3e009214b3ab70ec248d58a457197af95e3605bd9c9L12-R50)
* Increased the maximum grid container width from `980px` to `1008px` for better alignment with the new card sizing. (`src/components/panel/panel.css`, `src/components/results/results.css`) [[1]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0L44-R57) [[2]](diffhunk://#diff-261a3d038c3d7259ba2fc3e009214b3ab70ec248d58a457197af95e3605bd9c9L12-R50)

**Single event display enhancements:**

* Added a `single-event-grid` class to the grid container when only one event is present, centering the card and adjusting its width for both desktop and mobile breakpoints. (`src/components/results/Results.jsx`, `src/components/results/results.css`) [[1]](diffhunk://#diff-5d7320644bd6a6bbd324b724208ca83196f033e415033a1128037511ddcf4324L17-R17) [[2]](diffhunk://#diff-261a3d038c3d7259ba2fc3e009214b3ab70ec248d58a457197af95e3605bd9c9L12-R50)

These changes make the event cards and their grids more visually consistent and responsive, especially when displaying a single event or when viewed on different device sizes.