### PR TITLE
fix: height and cut off corrected

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,7 +13,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 16px;
   height: 100%;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,17 +14,28 @@ import 'dayjs/locale/en';
 import 'dayjs/locale/fr';
 
 const DEFAULT_WIDGET_HEIGHT = '1000px';
+const DIV_DEFAULT_WIDGET_HEIGHT = 'auto';
 
-function resolveWidgetHeight(height) {
+function isEmbeddedInIframe() {
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+}
+
+function resolveWidgetHeight(height, isIframe) {
+  const fallbackHeight = isIframe ? DEFAULT_WIDGET_HEIGHT : DIV_DEFAULT_WIDGET_HEIGHT;
+
   if (typeof height === 'number') {
-    return Number.isFinite(height) ? `${height}px` : DEFAULT_WIDGET_HEIGHT;
+    return Number.isFinite(height) ? `${height}px` : fallbackHeight;
   }
 
   if (typeof height === 'string') {
     const normalizedHeight = height.trim();
 
     if (!normalizedHeight) {
-      return DEFAULT_WIDGET_HEIGHT;
+      return fallbackHeight;
     }
 
     if (/^(?:\d+|\d*\.\d+)$/.test(normalizedHeight)) {
@@ -34,14 +45,14 @@ function resolveWidgetHeight(height) {
     return normalizedHeight;
   }
 
-  return DEFAULT_WIDGET_HEIGHT;
+  return fallbackHeight;
 }
 
 function App(props) {
   const { color, font, headerTitle, gtagId, ...widgetProps } = props;
   const locale = widgetProps.locale;
   const [loading, setLoading] = useState(true);
-  const resolvedHeight = resolveWidgetHeight(widgetProps.height);
+  const resolvedHeight = resolveWidgetHeight(widgetProps.height, isEmbeddedInIframe());
 
   useEffect(() => {
     try {

--- a/src/components/panel/panel.css
+++ b/src/components/panel/panel.css
@@ -34,7 +34,7 @@
   margin: 0px 8px 32px 8px;
   padding: 16px;
   box-shadow: var(--primary-box-shadow);
-  border-radius: lg;
+  border-radius: 12px;
   background-color: var(--primary-white-opaque);
 }
 
@@ -51,7 +51,7 @@
 @media (min-width: 550px) and (max-width: 820px) {
   #calendar-widget > .widget-layout .loader-wrapper > div {
     grid-template-columns: repeat(2, 246px);
-    justify-items: initial;
+    justify-items: stretch;
   }
 }
 
@@ -79,13 +79,13 @@
 @media (min-width: 820px) and (max-width: 1060px) {
   #calendar-widget > .widget-layout .loader-wrapper > div {
     grid-template-columns: repeat(3, 246px);
-    justify-items: initial;
+    justify-items: stretch;
   }
 }
 
 @media (min-width: 1060px) {
   #calendar-widget > .widget-layout .loader-wrapper > div {
     grid-template-columns: repeat(4, 246px);
-    justify-items: initial;
+    justify-items: stretch;
   }
 }

--- a/src/components/results/results.css
+++ b/src/components/results/results.css
@@ -20,21 +20,21 @@
 @media (min-width: 550px) and (max-width: 820px) {
   #calendar-widget > .widget-layout .grid-container {
     grid-template-columns: repeat(2, 246px);
-    justify-items: initial;
+    justify-items: stretch;
   }
 }
 
 @media (min-width: 820px) and (max-width: 1060px) {
   #calendar-widget > .widget-layout .grid-container {
     grid-template-columns: repeat(3, 246px);
-    justify-items: initial;
+    justify-items: stretch;
   }
 }
 
 @media (min-width: 1060px) {
   #calendar-widget > .widget-layout .grid-container {
     grid-template-columns: repeat(4, 246px);
-    justify-items: initial;
+    justify-items: stretch;
   }
 }
 


### PR DESCRIPTION
This pull request introduces several improvements to the widget's layout and appearance, along with a fix for widget height handling depending on whether the widget is embedded in an iframe. The main changes focus on more flexible and consistent grid layouts, improved styling, and smarter widget height resolution.

**Layout and Styling Improvements:**

* Changed grid item alignment in both the loader and results grid layouts to use `justify-items: stretch` for better consistency across different screen sizes in `panel.css` and `results.css`. [[1]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0L54-R54) [[2]](diffhunk://#diff-397ae2af5a55d14b8afb54edf87b9518924cf6098ae6c95f240bf295c3e4b3b0L82-R89) [[3]](diffhunk://#diff-261a3d038c3d7259ba2fc3e009214b3ab70ec248d58a457197af95e3605bd9c9L23-R37)
* Updated the panel border radius from a named value (`lg`) to a specific pixel value (`12px`) for more predictable styling in `panel.css`.
* Adjusted the main widget layout to use `justify-content: flex-start` instead of `space-between` for improved vertical alignment in `App.css`.

**Widget Height Handling:**

* Refactored the widget height resolution in `App.jsx` to distinguish between iframe and non-iframe contexts, using a fixed pixel height when embedded in an iframe and `auto` otherwise. This ensures the widget displays correctly in both scenarios. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R17-R38) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661L37-R55)